### PR TITLE
Fix subscription callbacks when unsubscribe in AuthorizeService.js in React template

### DIFF
--- a/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeService.js
+++ b/src/ProjectTemplates/Web.Spa.ProjectTemplates/content/React-CSharp/ClientApp/src/components/api-authorization/AuthorizeService.js
@@ -148,7 +148,7 @@ export class AuthorizeService {
             throw new Error(`Found an invalid number of subscriptions ${subscriptionIndex.length}`);
         }
 
-        this._callbacks = this._callbacks.splice(subscriptionIndex[0].index, 1);
+        this._callbacks.splice(subscriptionIndex[0].index, 1);
     }
 
     notifySubscribers() {


### PR DESCRIPTION
Fix subscription _callbacks array is re-assign when unsubscribe in AuthorizeService.js in React template. 

It will throw error after the first unsubscribe was called currently because the variable _callback is changed to the deleted elements. An array containing the deleted elements is returned when calling splice function in JavaScript means the variable reference should not be re-assign.